### PR TITLE
Return default value if vault item cannot be decrypted

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,7 +19,11 @@ module ChefVaultCookbook
 
   def chef_vault_item_or_default(bag, id, default = nil)
     if chef_vault_item_is_vault?(bag, id)
-      ChefVault::Item.load(bag, id)
+      begin
+        ChefVault::Item.load(bag, id)
+      rescue ChefVault::Exceptions::SecretDecryption
+        !default.nil? ? default : raise
+      end
     elsif !default.nil?
       default
     else

--- a/spec/unit/chef_vault_item_or_default_spec.rb
+++ b/spec/unit/chef_vault_item_or_default_spec.rb
@@ -42,5 +42,12 @@ describe ChefVaultCookbook do
         .and_raise(Net::HTTPServerException.new('Not Found', response))
       expect(dummy_class.new.chef_vault_item_or_default('bag', 'id', 'default')).to eq('default')
     end
+
+    it 'returns defined default if the item cannot be decrypted' do
+      allow(ChefVault::Item).to receive(:vault?).with('bag', 'id').and_return(true)
+      allow(ChefVault::Item).to receive(:load).with('bag', 'id').
+        and_raise(ChefVault::Exceptions::SecretDecryption)
+      expect(dummy_class.new.chef_vault_item_or_default('bag', 'id', 'default')).to eq('default')
+    end
   end
 end


### PR DESCRIPTION
In some cases, you can load the databag but not decrypt the vault item.
In such cases, we fallback on the provided default value.