### PR TITLE
Fix chefspec tests in ServerRunner mode

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -96,7 +96,7 @@ Chef::Node.send(:include, ChefSecretAttributes)
 class Chef
   # Monkeypatch Node
   class Node
-    alias chef_secret_old_save save unless defined?(chef_secret_old_save)
+    alias chef_secret_old_save save unless method_defined?(:chef_secret_old_save)
 
     def save
       unless @chef_secret_attributes.nil?

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 describe 'chef-secrets::default' do
   context 'When all attributes are default, on an unspecified platform' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new
+      runner = ChefSpec::ServerRunner.new
       runner.node.set['cookbook']['user'] = 'plaintext'
       runner.node.chef_secret_attribute_set(%w(cookbook pass), 'secret')
       runner.node.secret['cookbook']['sugar'] = 'value'


### PR DESCRIPTION
ServerRunner introduced a stack overflow since alias method was
done multiple times on the Chef::Node monkey patch.
