### PR TITLE
Update testing suite and lint

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -15,28 +15,30 @@ driver:
   require_chef_omnibus: 12.5.1
   instance_type: t2.micro
   associate_public_ip: true
+  iam_profile_name: test-kitchen
   region: <%= ENV['AWS_REGION'] || 'us-west-2' %>
   subnet_filter:
-    tag:   'Name'
+    tag: 'Name'
     value: <%= ENV['AWS_SUBNET'] || 'chef-testing-opensource-vpc-subnet' %>
   security_group_filter:
-    tag:   'Name'
+    tag: 'Name'
     value: <%= ENV['AWS_SECURITY_GROUP'] || 'chef-testing-opensource-vpc-security-group' %>
+  block_device_mappings:
+    - device_name: /dev/sda1
+      ebs:
+        volume_type: gp2
+        delete_on_termination: true
 
 transport:
   ssh_key: <%= ENV['HOME'] %>/.ssh/id_rsa
 
 provisioner:
-  name:        chef_zero
+  name: chef_zero
   clients_path: test/fixtures/clients
 
 platforms:
   - name: centos-7
-    driver:
-      image_id: ami-d2c924b2
   - name: windows-2012r2
-    driver:
-      image_id: ami-df8767bf
 
 suites:
   - name: default

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,13 @@
+---
 ### Disable rubocop for bundled chef-vault
 AllCops:
   Exclude:
     - 'ext/chef-vault/**/*'
     - 'libraries/chef-vault_*'
+### Disable block size for rspec
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
 ### Disable line length constraint
 Metrics/LineLength:
   Max: 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1.0
+- 2.3.1
 deploy:
   edge: true
   provider: chef-supermarket

--- a/Gemfile
+++ b/Gemfile
@@ -13,11 +13,11 @@ group :unit do
   gem 'chefspec'
 end
 
-gem 'chef-vault'
+gem 'chef-vault', '>= 3.0.0.rc1'
 
 group :ec2 do
   gem 'kitchen'
-  gem 'kitchen-ec2', :git => 'https://github.com/criteo-forks/kitchen-ec2.git', :branch => 'criteo'
-  gem 'winrm',      '~> 1.6'
-  gem 'winrm-fs',   '~> 0.3'
+  gem 'kitchen-ec2', git: 'https://github.com/criteo-forks/kitchen-ec2.git', branch: 'criteo'
+  gem 'winrm'
+  gem 'winrm-fs'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,5 +5,7 @@ license          'All rights reserved'
 description      'Installs/Configures chef-vault with helpers'
 long_description 'Installs/Configures chef-vault with helpers'
 version          '0.2.2'
+source_url       'https://github.com/criteo-cookbooks/chef-secrets'
+issues_url       'https://github.com/criteo-cookbooks/chef-secrets/issues'
 
 depends 'chef-vault'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,8 +9,8 @@ require 'spec_helper'
 describe 'chef-secrets::default' do
   context 'When all attributes are default, on an unspecified platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new
-      runner.node.set['cookbook']['user'] = 'plaintext'
+      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+      runner.node.default['cookbook']['user'] = 'plaintext'
       runner.node.chef_secret_attribute_set(%w(cookbook pass), 'secret')
       runner.node.secret['cookbook']['sugar'] = 'value'
       runner.node.chef_secret_attribute_clear(%w(cookbook pass))


### PR DESCRIPTION
Fixes RuboCop, FoodCritic, and ChefSpec.
Updates Travis to test on Ruby 2.3.1
Lets Test-Kitchen autoselect the AMI, also includes #5.