### PR TITLE
Cache secrets for 1..12 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ secret['cookbook']['password'] = chef_vault_item_or_default('vault', 'item', fal
 
 Note that a chef-vault item will always be a hash, so it may be better to set the fallback to a similar hash as well.
 
+## Caching
+
+Accessing many secrets on high latency links can be very long.
+`chef_vault_item_or_default` helper is able to cache for a few hours decrypted value on chef cache.
+
+Call it with `chef_vault_item_or_default('vault', 'item', fallback, use_cache: true)`.
+
+Cached entry has a TTL set randomly between 1 and 12 hours.
+
 ## Secret attributes
 
 ### Overview

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Accessing many secrets on high latency links can be very long.
 
 Call it with `chef_vault_item_or_default('vault', 'item', fallback, use_cache: true)`.
 
-Cached entry has a TTL set randomly between 1 and 12 hours.
+Cached entry has a TTL set randomly between 1 and 12 hours. This is to avoid refreshing all secrets at the same time (defeating the purpose of having caching).
+
 
 ## Secret attributes
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -18,10 +18,14 @@ module ChefVaultCookbook
   end
 
   # rubocop:disable Metrics/MethodLength
-  def chef_vault_item_or_default(bag, id, default = nil)
+  def chef_vault_item_or_default(bag, id, default = nil, use_cache: false)
+    cached_item = ItemCache.new(bag, id)
+    return cached_item.value if use_cache && cached_item.cached?
     if chef_vault_item_is_vault?(bag, id)
       begin
-        ChefVault::Item.load(bag, id)
+        ChefVault::Item.load(bag, id).tap do |value|
+          cached_item.write(value)
+        end
       rescue ChefVault::Exceptions::SecretDecryption
         !default.nil? ? default : raise
       end
@@ -32,6 +36,39 @@ module ChefVaultCookbook
     end
   end
   # rubocop:enable Metrics/MethodLength
+
+  class ItemCache
+    attr_reader :bag, :id
+
+    def initialize(bag, id)
+      @bag = bag
+      @id = id
+    end
+
+    def ttl_in_seconds
+      # ttl is between 1 and 12 hours
+      [*1..12].sample * 3600
+    end
+
+    def cache_file
+      ::File.join(Chef::Config[:cache_path], 'chef-secrets-cache', bag, id)
+    end
+
+    def cached?
+      ::File.exist?(cache_file) && ::File.mtime(cache_file) > Time.now - ttl_in_seconds
+    end
+
+    def value
+      JSON.parse(File.read(cache_file))
+    rescue => e
+      Chef::Log.warn "Unable to read #{cache_file}. Exception was #{e.class.name} #{e.message}"
+    end
+
+    def write(value)
+      FileUtils.mkdir_p(File.dirname(cache_file))
+      File.write(cache_file, value.to_json)
+    end
+  end
 end
 
 Chef::Node.send(:include, ChefVaultCookbook)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,6 +1,7 @@
 #
 # Load Chef Vault gem, fallback to bundled
 #
+require 'json'
 begin
   require 'chef-vault'
 rescue LoadError


### PR DESCRIPTION
This will improve behavior on nodes with high latency connection to the chef
server (especially with >50 secrets)

Change-Id: I7b965786fe284459fd21e1c3d09ac2bf48148730