### PR TITLE
Install chef-vault gem through metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,4 @@ source_url       'https://github.com/criteo-cookbooks/chef-secrets' if defined?(
 issues_url       'https://github.com/criteo-cookbooks/chef-secrets/issues' if defined?(issues_url)
 
 depends 'chef-vault', '~> 2.1' # cookbook chef-vault 3.0.0 breaks our behavior for now
+gem 'chef-vault', '3.4.3'


### PR DESCRIPTION
Issue https://github.com/chef/chef/issues/6038 has been worked around
since chef-vault does not depend on chef anymore.

Change-Id: Idf5b187c07c187fe83778e0dcd6dce2f350ee647