### PR TITLE
Bump fauxhai' centos' platform to fix chefspecs

### DIFF
--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 describe 'chef-secrets::default' do
   context 'When all attributes are default, on an unspecified platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.2.1511')
+      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.7.1908')
       runner.node.default['cookbook']['user'] = 'plaintext'
       runner.node.chef_secret_attribute_set(%w(cookbook pass), 'secret')
       runner.node.secret['cookbook']['sugar'] = 'value'


### PR DESCRIPTION
Centos 7.2 is not supported anymore by fauxhai, lets bump to 7.7