### PR TITLE
Handle ChefSolo in the chef_vault_item_is_vault? helper

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -21,6 +21,8 @@ module ChefVaultCookbook
     @existing_items["#{bag}::#{id}"] = begin
                                          Chef::DataBagItem.load(bag, id)
                                          true
+                                       rescue Chef::Exceptions::InvalidDataBagPath, Chef::Exceptions::InvalidDataBagItemID
+                                         false
                                        rescue Net::HTTPServerException => http_error
                                          puts http_error.response.code
                                          http_error.response.code.to_i == 404 ? false : raise


### PR DESCRIPTION
Depending on the Chef mode (solo, client) the exception raised by Chef when a DataBag or a DataBagItem might be different.
The original implementation was only handling the "client" mode with HTTP exceptions, however we should also handle the "solo" mode witch raises InvalidDataBagPath and InvalidDataBagItem exceptions.