### PR TITLE
Catch more failures in chef_vault_item_is_vault? & chef_vault_item_exists?

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sre-core@criteo.com'
 license          'All rights reserved'
 description      'Installs/Configures chef-vault with helpers'
 long_description 'Installs/Configures chef-vault with helpers'
-version          '1.0.0'
+version          '1.0.1'
 source_url       'https://github.com/criteo-cookbooks/chef-secrets' if defined?(source_url)
 issues_url       'https://github.com/criteo-cookbooks/chef-secrets/issues' if defined?(issues_url)
 

--- a/spec/unit/chef_vault_item_or_default_spec.rb
+++ b/spec/unit/chef_vault_item_or_default_spec.rb
@@ -12,13 +12,13 @@ describe ChefVaultCookbook do
     end
 
     it 'returns a ChefVault item if it exists, without a default' do
-      allow(Chef::DataBagItem).to receive(:load).with('bag', 'id').and_return('@@@@@@')
+      allow(ChefVault::Item).to receive(:vault?).with('bag', 'id').and_return(true)
       allow(ChefVault::Item).to receive(:load).with('bag', 'id').and_return('secret')
       expect(dummy_class.new.chef_vault_item_or_default('bag', 'id')).to eq('secret')
     end
 
     it 'returns a ChefVault item if it exists, with a default' do
-      allow(Chef::DataBagItem).to receive(:load).with('bag', 'id').and_return('@@@@@')
+      allow(ChefVault::Item).to receive(:vault?).with('bag', 'id').and_return(true)
       allow(ChefVault::Item).to receive(:load).with('bag', 'id').and_return('secret')
       expect(dummy_class.new.chef_vault_item_or_default('bag', 'id', 'default')).to eq('secret')
     end
@@ -36,6 +36,9 @@ describe ChefVaultCookbook do
       allow(Chef::DataBagItem).to receive(:load).with('bag', 'id')
         .and_raise(Net::HTTPServerException.new('Not Found', response))
       expect(dummy_class.new.chef_vault_item_or_default('bag', 'id', 'default')).to eq('default')
+      # chef-vault >= 4.0.5
+      allow(ChefVault::Item).to receive(:vault?).with('bag', 'id3').and_raise(ChefVault::Exceptions::ItemNotFound)
+      expect(dummy_class.new.chef_vault_item_or_default('bag', 'id3', 'default3')).to eq('default3')
     end
 
     it 'returns defined default if the vault databag does not exist (Solo mode)' do
@@ -48,7 +51,7 @@ describe ChefVaultCookbook do
     end
 
     it 'returns defined default if the item cannot be decrypted' do
-      allow(Chef::DataBagItem).to receive(:load).with('bag', 'id').and_return('@@@@')
+      allow(ChefVault::Item).to receive(:vault?).with('bag', 'id').and_return(true)
       allow(ChefVault::Item).to receive(:load).with('bag', 'id')
         .and_raise(ChefVault::Exceptions::SecretDecryption)
       expect(dummy_class.new.chef_vault_item_or_default('bag', 'id', 'default')).to eq('default')


### PR DESCRIPTION
Make chef_vault_item_is_vault? handles ::ChefVault::Item.vault? errors that means the Vault Item does not exist or is not a proper Vault item:

- In Solo mode, ChefVault::Item.vault? does not rescue nor convert the errors raised by DataBag and DataBagItem classes.
- In future version 4.0.5 ChefVault::Item.vault? is going to handle the HTTPServerException and raise an ItemNotFound exception.

Leverage chef_vault_item_is_vault? in chef_vault_item_exists? to avoid duplicating error handling. The only difference in these two methods is that the later one is memoizing the result.